### PR TITLE
Stripping UTF-8 byte-order-mark from source files

### DIFF
--- a/lib/pt.inputstream.js
+++ b/lib/pt.inputstream.js
@@ -28,6 +28,10 @@ pt.InputStream.prototype.read = function(filename) {
 };
 
 pt.InputStream.prototype.init = function(input) {
+    // Strip UTF-8 BOM
+    if (input.charAt(0) === '\uFEFF') {
+        input = input.slice(1);
+    }
     this.lines = input.split('\n');
     this.x = 0;
     this.y = 0;


### PR DESCRIPTION
Some code editors save files with it.
And most js tools and nodejs support this.
