### PR TITLE
у arguments нет метода join

### DIFF
--- a/lib/pt.parser.js
+++ b/lib/pt.parser.js
@@ -168,7 +168,7 @@ pt.Parser.prototype.matchAny = function() {
         }
     }
 
-    this.error( 'Expected: ' + arguments.join(', ') );
+    this.error( 'Expected: ' + Array.prototype.join.call(arguments, ', ') );
 };
 
 //  ---------------------------------------------------------------------------------------------------------------  //


### PR DESCRIPTION
В yate валится с ошибкой `arguments has now method join()`, если объявить external без типа
