### PR TITLE
Arguments don't have method 'join'

### DIFF
--- a/lib/pt.parser.js
+++ b/lib/pt.parser.js
@@ -168,7 +168,7 @@ pt.Parser.prototype.matchAny = function() {
         }
     }
 
-    this.error( 'Expected: ' + arguments.join(', ') );
+    this.error( 'Expected: ' + Array.prototype.slice.call(arguments).join(', ') );
 };
 
 //  ---------------------------------------------------------------------------------------------------------------  //


### PR DESCRIPTION
In yate 0.0.71 writing `module name` without apostrophes raises an error during compilation:

```
TypeError: Object #<Object> has no method 'join'
```

Instead of

```
Error: ERROR: Expected: ", '
at (8, 1) in /home/lunatik/Desktop/pfront/lib-header/header/header.yate:
...
```
