### PR TITLE
Парсер теперь может принимать input, а не только имя файла.

### DIFF
--- a/lib/pt.inputstream.js
+++ b/lib/pt.inputstream.js
@@ -11,28 +11,26 @@ var pt = require('./pt.js');
 
 pt.InputStream = function(src) {
     if (src) {
-        if (src.filename) {
-            this.read(src.filename);
+        if (src.input != null) {
+            this.init(src.input, src.filename);
         } else {
-            this.init(src.input);
+            this.read(src.filename);
         }
     }
 };
 
 pt.InputStream.prototype.read = function(filename) {
-    this.filename = path_.resolve(filename);
-
-    this.init( fs_.readFileSync(this.filename, 'utf-8') );
-
+    this.init(fs_.readFileSync(filename, 'utf-8'), filename);
     return this;
 };
 
-pt.InputStream.prototype.init = function(input) {
+pt.InputStream.prototype.init = function(input, filename) {
     //  Strip UTF-8 BOM
     if (input.charAt(0) === '\uFEFF') {
         input = input.slice(1);
     }
 
+    this.filename = filename ? path_.resolve(filename) : '<anonymous>';
     this.lines = input.split('\n');
     this.x = 0;
     this.y = 0;

--- a/lib/pt.parser.js
+++ b/lib/pt.parser.js
@@ -18,7 +18,8 @@ pt.Parser = function(grammar, factory) {
 //  ---------------------------------------------------------------------------------------------------------------  //
 
 pt.Parser.prototype.read = function(filename) {
-    this.input = new pt.InputStream( { filename: filename } );
+    var src = typeof filename === 'string' ? { filename: filename } : filename;
+    this.input = new pt.InputStream(src);
     this.skipper = null;
     this.cache = {};
 };


### PR DESCRIPTION
Нужно для in-memory компиляции.
Смотри pasaran/yate#251.