### PR TITLE
Поддержка CRLF в переводах строк

### DIFF
--- a/lib/pt.inputstream.js
+++ b/lib/pt.inputstream.js
@@ -31,7 +31,7 @@ pt.InputStream.prototype.init = function(input, filename) {
     }
 
     this.filename = filename ? path_.resolve(filename) : '<anonymous>';
-    this.lines = input.split('\n');
+    this.lines = input.split(/\r?\n/);
     this.x = 0;
     this.y = 0;
     this.line = this.lines[0];


### PR DESCRIPTION
Исходный баг: https://github.com/pasaran/parse-tools/issues/5